### PR TITLE
Fix `CombineAdjacentDelays()` issue combining non-adjacent delays

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -259,13 +259,8 @@ class CouplingMap:
 
         Returns:
             CouplingMap: A reduced coupling_map for the selected qubits.
-
-        Raises:
-            CouplingError: Reduced coupling map must be connected.
         """
-        from scipy.sparse import coo_matrix, csgraph
 
-        reduced_qubits = len(mapping)
         inv_map = [None] * (max(mapping) + 1)
         for idx, val in enumerate(mapping):
             inv_map[val] = idx
@@ -275,16 +270,6 @@ class CouplingMap:
         for edge in self.get_edges():
             if edge[0] in mapping and edge[1] in mapping:
                 reduced_cmap.append([inv_map[edge[0]], inv_map[edge[1]]])
-
-        # Verify coupling_map is connected
-        rows = np.array([edge[0] for edge in reduced_cmap], dtype=int)
-        cols = np.array([edge[1] for edge in reduced_cmap], dtype=int)
-        data = np.ones_like(rows)
-
-        mat = coo_matrix((data, (rows, cols)), shape=(reduced_qubits, reduced_qubits)).tocsr()
-
-        if csgraph.connected_components(mat)[0] != 1:
-            raise CouplingError("coupling_map must be connected.")
 
         return CouplingMap(reduced_cmap)
 
@@ -393,6 +378,9 @@ class CouplingMap:
             rows, cols, bidirectional=bidirectional
         )
         return cmap
+
+    def connected_components(self):
+        return rx.weakly_connected_components(self.graph)
 
     def largest_connected_component(self):
         """Return a set of qubits in the largest connected component."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary
Fix issue in `CombineAdjacentDelays()` where in some circuits non-adjacent delays are combined. This occurs due to sub-delays not being checked for connection after closing a larger delay. Fix involves disabling the connection check in `reduce()` in `CouplingMap()`.


### Details and comments
The fix to `CombineAdjacentDelays()` involves the following: 
- in `_open_delay()`, get the coupling map of the qubits in the delay to be opened
- this is done using `reduce()` from `CouplingMap()`. Since the reduced mapping is not necessarily connected, remove the connection check in `reduce()`
- The way `reduce()` is implemented has a special case where if the mapping only contains components with one qubit, then `reduce()` returns an empty coupling map (i.e [6, 4, 0, 2] returns [] but [6, 5, 0, 2] returns [{2}, {3}, {1, 0}]). Thus, check for this special case using `size()`. 
- Break the delay into multiple delays based on the connected components

